### PR TITLE
Endpoints

### DIFF
--- a/server/controllers/node.js
+++ b/server/controllers/node.js
@@ -119,9 +119,9 @@ module.exports = {
   },
   
   getLast24hrsOfReadingsForNode(req, res) {
-    if (req.body.timestamp != null) {
+    if (req.query.timestamp != null) {
       // convert the timestamp from the body into a date object
-      var time = req.body.timestamp
+      var time = req.query.timestamp
       var yr = parseInt(time.slice(0,4))
       var mth = parseInt(time.slice(6,8)) - 1
       var day = parseInt(time.slice(8,10))

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -21,10 +21,21 @@ module.exports = (app) => {
   app.post('/api/users', usersController.create) // create user
   app.put('/api/users/update', auth.validate, usersController.update) // update user fields
   app.put('/api/users/token', auth.validate, usersController.generateApiToken) // generate new api token for existing user
-  app.post('/api/users/getuser', auth.validate, usersController.getUser) // retrieve user + nodes
+  app.get('/api/users/getuser', auth.validate, usersController.getUser) // retrieve user + nodes
   app.delete('/api/users/delete', auth.validate, usersController.destroy) // delete user
 
   // other methods
+  app.get('/api/nodes/:nid/latest_reading',
+            auth.validate, nodesController.getLatestNodeReading) // retrieve latest reading for one of a user's nodes
+
+  app.get('/api/nodes/latest_readings/all',
+            auth.validate, nodesController.getLatestNodeReadingsForUser) // retrieve latest reading for each of a user's nodes
+
+  app.get('/api/nodes/prev_24h/:nid', auth.validate, nodesController.getLast24hrsOfReadingsForNode) // retrieve the last 24 hrs of readings for a node
+  
+  // deprecated
+  app.post('/api/users/getuser', auth.validate, usersController.getUser) // retrieve user + nodes
+  
   app.post('/api/nodes/:nid/latest_reading',
             auth.validate, nodesController.getLatestNodeReading) // retrieve latest reading for one of a user's nodes
 
@@ -32,4 +43,5 @@ module.exports = (app) => {
             auth.validate, nodesController.getLatestNodeReadingsForUser) // retrieve latest reading for each of a user's nodes
 
   app.post('/api/nodes/prev_24h/:nid', auth.validate, nodesController.getLast24hrsOfReadingsForNode) // retrieve the last 24 hrs of readings for a node
+  
 }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -31,7 +31,7 @@ module.exports = (app) => {
   app.get('/api/nodes/latest_readings/all',
             auth.validate, nodesController.getLatestNodeReadingsForUser) // retrieve latest reading for each of a user's nodes
 
-  app.get('/api/nodes/prev_24h/:nid', auth.validate, nodesController.getLast24hrsOfReadingsForNode) // retrieve the last 24 hrs of readings for a node
+  app.get('/api/nodes/prev_24h/:nid?', auth.validate, nodesController.getLast24hrsOfReadingsForNode) // retrieve the last 24 hrs of readings for a node
   
   // deprecated
   app.post('/api/users/getuser', auth.validate, usersController.getUser) // retrieve user + nodes


### PR DESCRIPTION
updated endpoints to use Authorization header to pass api_token; deprecated old endpoints that use request.body to pass api_token